### PR TITLE
 Support for multiple cursors / selections

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -6,5 +6,5 @@ export interface Range {
 }
 
 export interface SelectionStrategy {
-    grow(editor: TextEditor): Range | undefined;
+    grow(editor: TextEditor): Range[];
 }

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -109,7 +109,6 @@ export class TypescriptStrategy implements SelectionStrategy {
             const outRange = collapseWhitespace(text, nodeToRange(expansionNode));
             return outRange;
         }));
-        
         return outRanges;
     }
 }


### PR DESCRIPTION
Support selection grow/shrink for multiple cursors/selections. The built-in grow/shrink doesn't support this, so very smart select gets even smarter!

![screencast 2018-04-16 10-21-03](https://user-images.githubusercontent.com/723547/38825175-7850081c-4160-11e8-9f5f-e008593ed09b.gif)
